### PR TITLE
Update paginator.py

### DIFF
--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -155,7 +155,7 @@ class Page:
         # changed to lstrip() because that would remove all leading slashes and
         # thus make the workaround impossible. See
         # test_custom_pagination_pattern() for a verification of this.
-        if ret[0] == '/':
+        if ret.startswith('/'):
             ret = ret[1:]
         return ret
 


### PR DESCRIPTION
Check whether 'ret' starts with a slash, even when it's empty "".

ret can be an empty string -- such as when INDEX_URL is set to "" -- so the current code which checks ret[0] triggers an exception in that situation, "IndexError: string index out of range."

(I did try running the tests on a fresh clone of Pelican, but many of them don't seem to be working.)